### PR TITLE
Update to have one h1 in all pages

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/components/hero-post.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/hero-post.tsx
@@ -26,9 +26,9 @@ export const HeroPost = ({ title, coverImage, date, excerpt, slug }: Props) => {
 				/>
 			</div>
 			<div className="col-span-1 flex flex-col gap-2">
-				<h2 className="text-xl font-bold font-heading text-[#181D27] dark:text-neutral-50 lg:text-3xl">
+				<h1 className="text-xl font-bold font-heading text-[#181D27] dark:text-neutral-50 lg:text-3xl">
 					<ParamLink href={postURL} name={title} className='hover:underline' />
-				</h2>
+				</h1>
 				<ParamLink href={postURL}>
 					<p className="text-md text-[#414651] leading-[160%] dark:text-neutral-400">{excerpt}</p>
 				</ParamLink>

--- a/packages/blog-starter-kit/themes/enterprise/components/post-preview.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/post-preview.tsx
@@ -29,9 +29,9 @@ export const PostPreview = ({ title, coverImage, date, excerpt, slug }: Props) =
 				/>
 			</div>
 			<div className="col-span-1 flex flex-col gap-2">
-				<h1 className="text-lg font-bold font-heading text-[#181D27] dark:text-neutral-50">
+				<h3 className="text-lg font-bold font-heading text-[#181D27] dark:text-neutral-50">
 					<ParamLink href={postURL} name={title} className='hover:underline' />
-				</h1>
+				</h3>
 				<ParamLink href={postURL}>
 					<p className="text-md text-[#414651] dark:text-neutral-400">
 						{excerpt.length > 140 ? excerpt.substring(0, 140) + '…' : excerpt}

--- a/packages/blog-starter-kit/themes/enterprise/components/publication-logo.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/publication-logo.tsx
@@ -14,7 +14,7 @@ export const PublicationLogo = ({ isSidebar }: { isSidebar?: boolean }) => {
 	const PUBLICATION_LOGO = getPublicationLogo(publication, isSidebar);
 
 	return (
-		<h1 className="relative w-full">
+		<div className="relative w-full">
 			<ParamLink
 				href="https://www.getcollate.io/"
 				aria-label={`${publication.title} blog home page`}
@@ -38,6 +38,6 @@ export const PublicationLogo = ({ isSidebar }: { isSidebar?: boolean }) => {
 					</span>
 				)}
 			</ParamLink>
-		</h1>
+		</div>
 	);
 };

--- a/packages/blog-starter-kit/themes/enterprise/components/secondary-post.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/secondary-post.tsx
@@ -25,9 +25,9 @@ export const SecondaryPost = ({ title, coverImage, date, excerpt, slug }: Props)
 				/>
 			</div>
 			<div className="col-span-1 flex flex-col gap-2">
-				<h1 className="text-lg font-bold font-heading text-[#181D27] dark:text-neutral-50">
+				<h2 className="text-lg font-bold font-heading text-[#181D27] dark:text-neutral-50">
 					<ParamLink href={postURL} name={title} className='hover:underline' />
-				</h1>
+				</h2>
 				<ParamLink href={postURL}>
 					<p className="text-md text-[#414651] dark:text-neutral-400">
 						{excerpt.length > 100 ? excerpt.substring(0, 100) + '…' : excerpt}


### PR DESCRIPTION
Updated the blog-ui to ensure that every page contains only a single `<h1>` element. Having a single `<h1>` per page is important for accessibility and SEO best practices, as it provides a clear and consistent document structure for users and search engines.
