### PR TITLE
Remove Roadmap from footer

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
@@ -168,14 +168,6 @@ export const Footer = () => {
 								</li>
 								<li>
 									<ParamLink
-										href="https://www.getcollate.io/roadmap"
-										className="footer-link hover:underline"
-										target="_blank"
-										name="Roadmap"
-									/>
-								</li>
-								<li>
-									<ParamLink
 										href="https://docs.getcollate.io"
 										className="footer-link hover:underline"
 										target="_blank"

--- a/packages/blog-starter-kit/themes/enterprise/components/layout.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/layout.tsx
@@ -1,4 +1,3 @@
-import Script from 'next/script';
 import { Integrations } from './integrations';
 import { Meta } from './meta';
 


### PR DESCRIPTION
This PR removes the "Roadmap" link from the website footer.

- The Roadmap page is no longer relevant or needed in the footer navigation as the page has been deleted from the site.